### PR TITLE
feat(FTL-8082): CSV validation messages rendering in 'affinidi' output

### DIFF
--- a/src/features/issuance/csvCreationService.ts
+++ b/src/features/issuance/csvCreationService.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { l10n, OpenDialogOptions, window, workspace } from 'vscode'
 import { Schema } from '../../shared/types'
-import { askForProjectId } from '../iam/askForProjectId'
+import { iamHelper } from '../iam/iamHelper'
 import { showQuickPick } from '../../utils/showQuickPick'
 import { parseUploadError } from './csvUploadError'
 import { requireProjectSummary } from '../iam/requireProjectSummary'
@@ -26,7 +26,7 @@ const implementationLabels = {
 
 export const openCsvTemplate = async (input: TemplateInput) => {
   const consoleAuthToken = await authHelper.getConsoleAuthToken()
-  const projectId = input?.projectId ?? (await askForProjectId({ consoleAuthToken }))
+  const projectId = input?.projectId ?? (await iamHelper.askForProjectId({ consoleAuthToken }))
   if (!projectId) {
     return
   }


### PR DESCRIPTION
CSV validation messages now appear in the 'Affinidi' output channel

<img width="1572" alt="Screenshot 2022-11-18 at 14 50 40" src="https://user-images.githubusercontent.com/118436059/202720161-4cce7f82-7fbe-40f3-856e-52992f938059.png">
