### PR TITLE
feat: [FTL-9016] Amended analytics to track telemetry disabled events

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,13 @@ export async function activateInternal(context: ExtensionContext) {
     }
   })
 
+  workspace.onDidChangeConfiguration((event) => {
+    const affected = event.affectsConfiguration('affinidi.telemetry.enabled')
+    if (affected) {
+      telemetryHelpers.registerTelemetryChanged()
+    }
+  })
+
   context.subscriptions.push(
     commands.registerCommand('affinidiExplorer.refreshAll', () => {
       telemetryHelpers.trackCommand('affinidiExplorer.refreshAll')

--- a/src/features/telemetry/analyticsStreamApiService.ts
+++ b/src/features/telemetry/analyticsStreamApiService.ts
@@ -45,13 +45,15 @@ export const sendRawAnalyticsEvent = async ({
   name,
   subCategory,
   metadata,
+  ignoreConfig,
 }: {
   name: EventNames
   subCategory?: EventSubCategory
   metadata?: any
+  ignoreConfig?: boolean
 }): Promise<void> => {
   if (credentialsVault.getEnvironment() !== 'prod') return
-  if (!telemetryHelpers.isTelemetryEnabled()) {
+  if (!telemetryHelpers.isTelemetryEnabled() && !ignoreConfig) {
     return
   }
 

--- a/src/features/telemetry/telemetryHelpers.ts
+++ b/src/features/telemetry/telemetryHelpers.ts
@@ -45,21 +45,12 @@ async function askUserForTelemetryConsent() {
 }
 
 function registerTelemetryChanged() {
-  if (!isTelemetryEnabled()) {
-    sendRawAnalyticsEvent({
-      name: EventNames.extensionInitialized,
-      subCategory: EventSubCategory.affinidiExtension,
-      metadata: { analytics: 'disabled' },
-      ignoreConfig: true,
-    })
-  }
-  if (isTelemetryEnabled()) {
-    sendRawAnalyticsEvent({
-      name: EventNames.extensionInitialized,
-      subCategory: EventSubCategory.affinidiExtension,
-      metadata: { analytics: 'enabled' },
-    })
-  }
+  sendRawAnalyticsEvent({
+    name: EventNames.extensionInitialized,
+    subCategory: EventSubCategory.affinidiExtension,
+    metadata: { analytics: isTelemetryEnabled() ? 'enabled' : 'disabled' },
+    ignoreConfig: true,
+  })
 }
 
 function trackCommand(commandId: string, metadata?: any) {

--- a/src/features/telemetry/telemetryHelpers.ts
+++ b/src/features/telemetry/telemetryHelpers.ts
@@ -21,24 +21,44 @@ async function askUserForTelemetryConsent() {
 
     switch (consent) {
       case CONSENT.accept:
-        await workspace.getConfiguration().update('affinidi.telemetry.enabled', true, true)
-
         sendRawAnalyticsEvent({
           name: EventNames.extensionInitialized,
           subCategory: EventSubCategory.affinidiExtension,
+          metadata: { analytics: 'enabled' },
         })
+        await workspace.getConfiguration().update('affinidi.telemetry.enabled', true, true)
+
         break
       case CONSENT.deny:
-        await workspace.getConfiguration().update('affinidi.telemetry.enabled', false, true)
         sendRawAnalyticsEvent({
           name: EventNames.extensionInitialized,
           subCategory: EventSubCategory.affinidiExtension,
           metadata: { analytics: 'disabled' },
+          ignoreConfig: true,
         })
+        await workspace.getConfiguration().update('affinidi.telemetry.enabled', false, true)
         break
       default:
         throw new Error(`${errorMessage.unknownConsentType} ${consent}`)
     }
+  }
+}
+
+function registerTelemetryChanged() {
+  if (!isTelemetryEnabled()) {
+    sendRawAnalyticsEvent({
+      name: EventNames.extensionInitialized,
+      subCategory: EventSubCategory.affinidiExtension,
+      metadata: { analytics: 'disabled' },
+      ignoreConfig: true,
+    })
+  }
+  if (isTelemetryEnabled()) {
+    sendRawAnalyticsEvent({
+      name: EventNames.extensionInitialized,
+      subCategory: EventSubCategory.affinidiExtension,
+      metadata: { analytics: 'enabled' },
+    })
   }
 }
 
@@ -71,4 +91,5 @@ export const telemetryHelpers = {
   askUserForTelemetryConsent,
   trackCommand,
   trackSnippetInserted,
+  registerTelemetryChanged,
 }


### PR DESCRIPTION
This PR amends the telemetry service as follows:
- we now track both enabling and disabling telemetry at installation
- we also track both events when changed via the Extension settings panel or the settings.json file